### PR TITLE
feat(api): 添加DEEP_SEEK_CHAT_AUTHORIZATION环境变量支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,10 @@ MiniMax（海螺AI）接口转API [hailuo-free-api](https://github.com/LLM-Red-T
 
 请准备一台具有公网IP的服务器并将8000端口开放。
 
-拉取镜像并启动服务
+拉取镜像并启动服务，DEEP_SEEK_CHAT_AUTHORIZATION 环境变量未chatweb网页版本的token。
 
 ```shell
-docker run -it -d --init --name deepseek-free-api -p 8000:8000 -e TZ=Asia/Shanghai vinlic/deepseek-free-api:latest
+docker run -it -d --init --name deepseek-free-api -p 8000:8000 -e TZ=Asia/Shanghai -e DEEP_SEEK_CHAT_AUTHORIZATION=xxx vinlic/deepseek-free-api:latest
 ```
 
 查看服务实时日志

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+
+services:
+  deepseek-free-api:
+    container_name: deepseek-free-api
+    image: vinlic/deepseek-free-api:latest
+    restart: always
+    ports:
+      - "8000:8000"
+    environment:
+      - TZ=Asia/Shanghai
+      - DEEP_SEEK_CHAT_AUTHORIZATION=UFV8fRYleCSOxOahFJxqZXOGhMSXVqIK1n7SeD4chb+XYMMKEOJtOmDKffP2W6Km

--- a/src/api/routes/chat.ts
+++ b/src/api/routes/chat.ts
@@ -4,6 +4,10 @@ import Request from '@/lib/request/Request.ts';
 import Response from '@/lib/response/Response.ts';
 import chat from '@/api/controllers/chat.ts';
 
+
+const DEEP_SEEK_CHAT_AUTHORIZATION = process.env.DEEP_SEEK_CHAT_AUTHORIZATION;
+
+
 export default {
 
     prefix: '/v1/chat',
@@ -15,6 +19,11 @@ export default {
                 .validate('body.conversation_id', v => _.isUndefined(v) || _.isString(v))
                 .validate('body.messages', _.isArray)
                 .validate('headers.authorization', _.isString)
+
+            // 如果请求中没有token则读取环境变量的配置
+            if (!request.headers.authorization) {
+                request.headers.authorization = DEEP_SEEK_CHAT_AUTHORIZATION;
+            }
             // token切分
             const tokens = chat.tokenSplit(request.headers.authorization);
             // 随机挑选一个token


### PR DESCRIPTION
在README.md中更新了启动命令，添加了DEEP_SEEK_CHAT_AUTHORIZATION环境变量的说明。新增了docker-compose.yml文件，用于配置DEEP_SEEK_CHAT_AUTHORIZATION环境变量。在src/api/routes/chat.ts中添加了环境变量读取逻辑，当请求头中没有token时，使用环境变量中的配置。