### PR TITLE
feat(chat): Fold the output of the reference content of the search mo…

### DIFF
--- a/src/api/controllers/chat.ts
+++ b/src/api/controllers/chat.ts
@@ -355,6 +355,8 @@ async function createCompletionStream(
 
     // 消息预处理
     const prompt = messagesPrepare(messages);
+    logger.info(`messages after prepare: `);
+    logger.info(prompt);
 
     // 解析引用对话ID
     const [refSessionId, refParentMsgId] = refConvId?.split('@') || [];
@@ -507,6 +509,7 @@ function messagesPrepare(messages: any[]): string {
   return mergedBlocks
     .map((block, index) => {
       if (block.role === "assistant") {
+        block.text = block.text.replace(/<details><summary>参考检索<\/summary><pre>检索 .*<\/pre><\/details>/s, ``);
         return `<｜Assistant｜>${block.text}<｜end▁of▁sentence｜>`;
       }
       
@@ -668,7 +671,7 @@ function createTransStream(model: string, stream: any, refConvId: string, endCal
             choices: [
               {
                 index: 0,
-                delta: { role: "assistant", content: refContent },
+                delta: { role: "assistant", content: `<details><summary>参考检索</summary><pre>` + refContent + `</pre></details>` },
                 finish_reason: null,
               },
             ],


### PR DESCRIPTION
#64 
使用 markdown 标签折叠联网的 参考检索，并且在多轮发送消息是将先去的 参考检索 去除掉，否则无法正常使用，会返回“还没学会”
<img width="730" alt="iShot_2025-02-05_02 37 07" src="https://github.com/user-attachments/assets/cfca3ca1-1a35-4b71-a2cc-50097c93b413" />
<img width="823" alt="iShot_2025-02-05_02 41 31" src="https://github.com/user-attachments/assets/81a065ad-ea4e-4ed4-a55b-41f72e2fb9ad" />
